### PR TITLE
Implement basic multi-screen navigation and UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "expo": "^53.0.20",
         "expo-asset": "~11.1.4",
         "expo-dev-client": "~5.2.4",
+        "expo-linear-gradient": "~14.0.1",
         "expo-linking": "~7.1.7",
         "expo-splash-screen": "~0.30.7",
         "expo-system-ui": "~5.0.6",
@@ -4277,6 +4278,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-14.0.2.tgz",
+      "integrity": "sha512-nvac1sPUfFFJ4mY25UkvubpUV/olrBH+uQw5k+beqSvQaVQiUfFtYzfRr+6HhYBNb4AEsOtpsCRkpDww3M2iGQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "expo": "^53.0.20",
     "expo-asset": "~11.1.4",
     "expo-dev-client": "~5.2.4",
+    "expo-linear-gradient": "~14.0.1",
     "expo-linking": "~7.1.7",
     "expo-splash-screen": "~0.30.7",
     "expo-system-ui": "~5.0.6",

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+import { colors, spacing } from '../styles';
+
+const avatar = require('../assets/newspaper.png');
+
+interface Props {
+  text: string;
+}
+
+export function CommentItem({ text }: Props) {
+  return (
+    <View style={styles.row}>
+      <Image source={avatar} style={styles.avatar} />
+      <Text style={styles.text}>{text}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingVertical: 10,
+    paddingHorizontal: spacing.padding,
+    gap: 10,
+  },
+  avatar: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+  },
+  text: {
+    color: colors.textPrimary,
+    flex: 1,
+  },
+});

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { StyleSheet, TextInput, TextInputProps } from 'react-native';
+import { colors, radius, spacing } from '../styles';
+
+export function InputField(props: TextInputProps) {
+  return (
+    <TextInput
+      placeholderTextColor="rgba(255,255,255,0.7)"
+      style={styles.input}
+      {...props}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  input: {
+    width: '82%',
+    height: 48,
+    borderRadius: radius.input,
+    backgroundColor: 'rgba(255,255,255,0.25)',
+    paddingHorizontal: spacing.padding,
+    color: colors.textPrimary,
+    marginVertical: 8,
+  },
+});

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import { colors, radius, spacing } from '../styles';
+
+interface Props {
+  onPress?: () => void;
+}
+
+const avatar = require('../assets/newspaper.png');
+const postImage = require('../assets/bell.png');
+
+export function PostCard({ onPress }: Props) {
+  return (
+    <TouchableOpacity onPress={onPress} style={styles.card}>
+      <View style={styles.header}>
+        <Image source={avatar} style={styles.avatar} />
+        <Text style={styles.name}>Eduardo Kaic</Text>
+      </View>
+      <Image source={postImage} style={styles.image} />
+      <View style={styles.actions}>
+        <View style={styles.actionGroup}>
+          <FontAwesome name="heart" size={22} color={colors.textPrimary} />
+          <Text style={styles.count}>168K</Text>
+        </View>
+        <View style={styles.actionGroup}>
+          <FontAwesome name="share" size={22} color={colors.textPrimary} />
+          <Text style={styles.count}>168K</Text>
+        </View>
+        <View style={styles.actionGroup}>
+          <FontAwesome name="eye" size={22} color={colors.textPrimary} />
+          <Text style={styles.count}>136K</Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.card,
+    borderRadius: radius.card,
+    marginVertical: 12,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.padding,
+    gap: 10,
+  },
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+  },
+  name: {
+    color: colors.textPrimary,
+    fontSize: 16,
+  },
+  image: {
+    width: '100%',
+    height: 200,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingVertical: 12,
+  },
+  actionGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  count: {
+    color: colors.textPrimary,
+  },
+});

--- a/src/components/SocialButton.tsx
+++ b/src/components/SocialButton.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { TouchableOpacity, StyleSheet } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
+import { colors } from '../styles';
+
+interface Props {
+  name: React.ComponentProps<typeof FontAwesome>['name'];
+  onPress?: () => void;
+}
+
+export function SocialButton({ name, onPress }: Props) {
+  return (
+    <TouchableOpacity style={styles.button} onPress={onPress}>
+      <FontAwesome name={name} size={24} color={colors.dark} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: colors.lightButton,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginHorizontal: 10,
+  },
+});

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,105 +1,67 @@
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { HeaderButton, Text } from '@react-navigation/elements';
-import {
-  createStaticNavigation,
-  StaticParamList,
-} from '@react-navigation/native';
+import React from 'react';
+import { NavigationContainer, Theme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { Image } from 'react-native';
-import bell from '../assets/bell.png';
-import newspaper from '../assets/newspaper.png';
-import { Home } from './screens/Home';
-import { Profile } from './screens/Profile';
-import { Settings } from './screens/Settings';
-import { Updates } from './screens/Updates';
-import { NotFound } from './screens/NotFound';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { FontAwesome } from '@expo/vector-icons';
+import { colors } from '../styles';
+import { LoginScreen } from '../screens/LoginScreen';
+import { RegisterScreen } from '../screens/RegisterScreen';
+import { FeedScreen } from '../screens/FeedScreen';
+import { SearchScreen } from '../screens/SearchScreen';
+import { CreateScreen } from '../screens/CreateScreen';
+import { CommunityScreen } from '../screens/CommunityScreen';
+import { ProfileScreen } from '../screens/ProfileScreen';
+import { CommentsScreen } from '../screens/CommentsScreen';
+import { ChatScreen } from '../screens/ChatScreen';
 
-const HomeTabs = createBottomTabNavigator({
-  screens: {
-    Home: {
-      screen: Home,
-      options: {
-        title: 'Feed',
-        tabBarIcon: ({ color, size }) => (
-          <Image
-            source={newspaper}
-            tintColor={color}
-            style={{
-              width: size,
-              height: size,
-            }}
-          />
-        ),
-      },
-    },
-    Updates: {
-      screen: Updates,
-      options: {
-        tabBarIcon: ({ color, size }) => (
-          <Image
-            source={bell}
-            tintColor={color}
-            style={{
-              width: size,
-              height: size,
-            }}
-          />
-        ),
-      },
-    },
-  },
-});
+const Stack = createNativeStackNavigator();
+const Tab = createBottomTabNavigator();
 
-const RootStack = createNativeStackNavigator({
-  screens: {
-    HomeTabs: {
-      screen: HomeTabs,
-      options: {
-        title: 'Home',
+function AppTabs() {
+  return (
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
         headerShown: false,
-      },
-    },
-    Profile: {
-      screen: Profile,
-      linking: {
-        path: ':user(@[a-zA-Z0-9-_]+)',
-        parse: {
-          user: (value) => value.replace(/^@/, ''),
+        tabBarStyle: {
+          backgroundColor: '#111111',
+          borderTopLeftRadius: 24,
+          borderTopRightRadius: 24,
+          height: 64,
+          paddingBottom: 10,
         },
-        stringify: {
-          user: (value) => `@${value}`,
+        tabBarActiveTintColor: colors.accent,
+        tabBarInactiveTintColor: 'rgba(255,255,255,0.7)',
+        tabBarIcon: ({ color, size }) => {
+          const icons: any = {
+            Feed: 'home',
+            Search: 'search',
+            Create: 'plus-circle',
+            Community: 'users',
+            Profile: 'user',
+          };
+          return <FontAwesome name={icons[route.name]} size={size} color={color} />;
         },
-      },
-    },
-    Settings: {
-      screen: Settings,
-      options: ({ navigation }) => ({
-        presentation: 'modal',
-        headerRight: () => (
-          <HeaderButton onPress={navigation.goBack}>
-            <Text>Close</Text>
-          </HeaderButton>
-        ),
-      }),
-    },
-    NotFound: {
-      screen: NotFound,
-      options: {
-        title: '404',
-      },
-      linking: {
-        path: '*',
-      },
-    },
-  },
-});
+      })}
+    >
+      <Tab.Screen name="Feed" component={FeedScreen} />
+      <Tab.Screen name="Search" component={SearchScreen} />
+      <Tab.Screen name="Create" component={CreateScreen} />
+      <Tab.Screen name="Community" component={CommunityScreen} />
+      <Tab.Screen name="Profile" component={ProfileScreen} />
+    </Tab.Navigator>
+  );
+}
 
-export const Navigation = createStaticNavigation(RootStack);
-
-type RootStackParamList = StaticParamList<typeof RootStack>;
-
-declare global {
-  namespace ReactNavigation {
-    interface RootParamList extends RootStackParamList {}
-  }
+export function Navigation({ theme, linking, onReady }: { theme: Theme; linking?: any; onReady?: () => void }) {
+  return (
+    <NavigationContainer theme={theme} linking={linking} onReady={onReady}>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Register" component={RegisterScreen} />
+        <Stack.Screen name="AppTabs" component={AppTabs} />
+        <Stack.Screen name="Comments" component={CommentsScreen} />
+        <Stack.Screen name="Chat" component={ChatScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
 }

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { View, FlatList, StyleSheet, TextInput, TouchableOpacity, Text } from 'react-native';
+import { colors, spacing } from '../styles';
+import { FontAwesome } from '@expo/vector-icons';
+
+export function ChatScreen() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Chat Geral</Text>
+        <FontAwesome name="cog" size={24} color={colors.textPrimary} />
+      </View>
+      <FlatList
+        data={[1,2,3]}
+        keyExtractor={(item) => item.toString()}
+        renderItem={() => <Text style={styles.message}>Mensagem</Text>}
+        contentContainerStyle={{ padding: spacing.padding }}
+      />
+      <View style={styles.inputRow}>
+        <FontAwesome name="paperclip" size={24} color={colors.textPrimary} />
+        <FontAwesome name="image" size={24} color={colors.textPrimary} style={{ marginLeft: 10 }} />
+        <FontAwesome name="smile-o" size={24} color={colors.textPrimary} style={{ marginLeft: 10 }} />
+        <TextInput style={styles.input} placeholder="Mensagem" placeholderTextColor="rgba(255,255,255,0.7)" />
+        <TouchableOpacity>
+          <FontAwesome name="send" size={24} color={colors.textPrimary} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#2F2F2F',
+  },
+  header: {
+    height: 60,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.padding,
+    backgroundColor: '#2F2F2F',
+  },
+  title: {
+    color: colors.textPrimary,
+    fontSize: 18,
+  },
+  message: {
+    color: colors.textPrimary,
+    marginVertical: 4,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.padding,
+    backgroundColor: colors.dark,
+  },
+  input: {
+    flex: 1,
+    marginHorizontal: 10,
+    color: colors.textPrimary,
+  },
+});

--- a/src/screens/CommentsScreen.tsx
+++ b/src/screens/CommentsScreen.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, FlatList, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
+import { PostCard } from '../components/PostCard';
+import { CommentItem } from '../components/CommentItem';
+import { colors, spacing } from '../styles';
+import { FontAwesome } from '@expo/vector-icons';
+
+export function CommentsScreen() {
+  return (
+    <View style={styles.container}>
+      <FlatList
+        ListHeaderComponent={<PostCard />}
+        data={[1, 2, 3]}
+        keyExtractor={(item) => item.toString()}
+        renderItem={() => <CommentItem text="Comentário" />}
+        contentContainerStyle={{ paddingBottom: 100 }}
+      />
+      <View style={styles.inputRow}>
+        <TouchableOpacity>
+          <FontAwesome name="image" size={24} color={colors.textPrimary} />
+        </TouchableOpacity>
+        <TextInput style={styles.input} placeholder="Digite um comentário" placeholderTextColor="rgba(255,255,255,0.7)" />
+        <TouchableOpacity>
+          <FontAwesome name="send" size={24} color={colors.textPrimary} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.padding,
+    backgroundColor: colors.dark,
+  },
+  input: {
+    flex: 1,
+    marginHorizontal: 10,
+    color: colors.textPrimary,
+  },
+});

--- a/src/screens/CommunityScreen.tsx
+++ b/src/screens/CommunityScreen.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+import { colors, spacing } from '../styles';
+
+export function CommunityScreen({ navigation }: any) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.banner}>
+        <Text style={styles.bannerText}>Knights of the Blood</Text>
+        <Text style={styles.status}>● 143 Online</Text>
+      </View>
+      <FlatList
+        data={[{ name: '# Chat Geral' }, { name: 'Voice 1' }]}
+        keyExtractor={(item, index) => index.toString()}
+        renderItem={({ item }) => (
+          <Text
+            style={styles.channel}
+            onPress={() => navigation.navigate('Chat')}
+          >
+            {item.name}
+          </Text>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  banner: {
+    padding: spacing.padding,
+    backgroundColor: colors.card,
+  },
+  bannerText: {
+    color: colors.textPrimary,
+    fontSize: 18,
+  },
+  status: {
+    color: '#2ECC71',
+    marginTop: 4,
+  },
+  channel: {
+    color: colors.textPrimary,
+    padding: spacing.padding,
+    borderBottomWidth: 1,
+    borderBottomColor: '#2B2B2B',
+  },
+});

--- a/src/screens/CreateScreen.tsx
+++ b/src/screens/CreateScreen.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors } from '../styles';
+
+export function CreateScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Create</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: colors.textPrimary,
+  },
+});

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, FlatList, StyleSheet } from 'react-native';
+import { PostCard } from '../components/PostCard';
+import { colors } from '../styles';
+
+export function FeedScreen({ navigation }: any) {
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={[1, 2, 3]}
+        keyExtractor={(item) => item.toString()}
+        renderItem={() => <PostCard onPress={() => navigation.navigate('Comments')} />}
+        contentContainerStyle={{ paddingBottom: 80 }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    paddingHorizontal: 0,
+  },
+});

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { InputField } from '../components/InputField';
+import { SocialButton } from '../components/SocialButton';
+import { colors, radius } from '../styles';
+
+export function LoginScreen({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#2E39E9', '#020013']} style={styles.container}>
+      <InputField placeholder="Informe seu e-mail" />
+      <InputField placeholder="Informe sua senha" secureTextEntry />
+      <View style={styles.socialRow}>
+        <SocialButton name="google" />
+        <SocialButton name="facebook" />
+      </View>
+      <TouchableOpacity
+        style={styles.mainButton}
+        onPress={() => navigation.replace('AppTabs')}
+      >
+        <Text style={styles.mainButtonText}>Fazer Login</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={styles.mainButton}
+        onPress={() => navigation.navigate('Register')}
+      >
+        <Text style={styles.mainButtonText}>Criar Cadastro</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  socialRow: {
+    flexDirection: 'row',
+    marginVertical: 16,
+  },
+  mainButton: {
+    width: '84%',
+    height: 52,
+    borderRadius: radius.button,
+    backgroundColor: colors.lightButton,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 12,
+  },
+  mainButtonText: {
+    color: '#111111',
+    fontWeight: 'bold',
+  },
+});

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors } from '../styles';
+
+export function ProfileScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Profile</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: colors.textPrimary,
+  },
+});

--- a/src/screens/RegisterScreen.tsx
+++ b/src/screens/RegisterScreen.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { InputField } from '../components/InputField';
+import { colors, radius } from '../styles';
+
+export function RegisterScreen({ navigation }: any) {
+  return (
+    <LinearGradient colors={['#2E39E9', '#020013']} style={styles.container}>
+      <InputField placeholder="Informe seu e-mail" />
+      <InputField placeholder="Crie sua senha" secureTextEntry />
+      <TouchableOpacity style={styles.mainButton}>
+        <Text style={styles.mainButtonText}>Criar Conta</Text>
+      </TouchableOpacity>
+      <TouchableOpacity onPress={() => navigation.goBack()}>
+        <Text style={styles.link}>Fazer Login</Text>
+      </TouchableOpacity>
+    </LinearGradient>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  mainButton: {
+    width: '84%',
+    height: 52,
+    borderRadius: radius.button,
+    backgroundColor: colors.lightButton,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 20,
+  },
+  mainButtonText: {
+    color: '#111111',
+    fontWeight: 'bold',
+  },
+  link: {
+    color: colors.textPrimary,
+    marginTop: 12,
+  },
+});

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors } from '../styles';
+
+export function SearchScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Search</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  text: {
+    color: colors.textPrimary,
+  },
+});

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,0 +1,19 @@
+export const colors = {
+  background: '#1E1E1E',
+  card: '#2F2F2F',
+  dark: '#151515',
+  accent: '#1E2AD2',
+  neon: '#00FF66',
+  lightButton: '#D9D9D9',
+  textPrimary: '#FFFFFF',
+};
+
+export const spacing = {
+  padding: 20,
+};
+
+export const radius = {
+  card: 16,
+  input: 12,
+  button: 24,
+};


### PR DESCRIPTION
## Summary
- add login and register flows with gradient backgrounds and social buttons
- implement feed, comments, chat, and community screens
- configure stack and tab navigation with themed bottom bar

## Testing
- `npm install`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e98a4ecbc8320845b5286475619d4