### PR TITLE
feat: enhance feed UI with animated icons and stories bar

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
-import { FontAwesome } from '@expo/vector-icons';
+import { View, Text, Image, StyleSheet, TouchableOpacity, Animated } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { colors, radius, spacing } from '../styles';
 
 interface Props {
@@ -11,6 +11,55 @@ const avatar = require('../assets/newspaper.png');
 const postImage = require('../assets/bell.png');
 
 export function PostCard({ onPress }: Props) {
+  const [liked, setLiked] = React.useState(false);
+  const likeScale = React.useRef(new Animated.Value(1)).current;
+  const likeColor = React.useRef(new Animated.Value(0)).current;
+
+  const AnimatedIcon = Animated.createAnimatedComponent(Ionicons);
+
+  const handleLike = () => {
+    const toValue = liked ? 0 : 1;
+    setLiked(!liked);
+    Animated.parallel([
+      Animated.spring(likeScale, {
+        toValue: 1.3,
+        useNativeDriver: true,
+      }),
+      Animated.timing(likeColor, {
+        toValue,
+        duration: 300,
+        useNativeDriver: false,
+      }),
+    ]).start(() => {
+      Animated.spring(likeScale, {
+        toValue: 1,
+        useNativeDriver: true,
+      }).start();
+    });
+  };
+
+  const colorInterpolation = likeColor.interpolate({
+    inputRange: [0, 1],
+    outputRange: [colors.textPrimary, '#ff2d55'],
+  });
+
+  const shareScale = React.useRef(new Animated.Value(1)).current;
+  const eyeScale = React.useRef(new Animated.Value(1)).current;
+
+  const handleShare = () => {
+    Animated.sequence([
+      Animated.spring(shareScale, { toValue: 1.2, useNativeDriver: true }),
+      Animated.spring(shareScale, { toValue: 1, useNativeDriver: true }),
+    ]).start();
+  };
+
+  const handleView = () => {
+    Animated.sequence([
+      Animated.spring(eyeScale, { toValue: 1.2, useNativeDriver: true }),
+      Animated.spring(eyeScale, { toValue: 1, useNativeDriver: true }),
+    ]).start();
+  };
+
   return (
     <TouchableOpacity onPress={onPress} style={styles.card}>
       <View style={styles.header}>
@@ -19,18 +68,27 @@ export function PostCard({ onPress }: Props) {
       </View>
       <Image source={postImage} style={styles.image} />
       <View style={styles.actions}>
-        <View style={styles.actionGroup}>
-          <FontAwesome name="heart" size={22} color={colors.textPrimary} />
+        <TouchableOpacity style={styles.actionGroup} onPress={handleLike}>
+          <AnimatedIcon
+            name={liked ? 'heart' : 'heart-outline'}
+            size={22}
+            color={colorInterpolation}
+            style={{ transform: [{ scale: likeScale }] }}
+          />
           <Text style={styles.count}>168K</Text>
-        </View>
-        <View style={styles.actionGroup}>
-          <FontAwesome name="share" size={22} color={colors.textPrimary} />
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.actionGroup} onPress={handleShare}>
+          <Animated.View style={{ transform: [{ scale: shareScale }] }}>
+            <Ionicons name="share-social-outline" size={22} color={colors.textPrimary} />
+          </Animated.View>
           <Text style={styles.count}>168K</Text>
-        </View>
-        <View style={styles.actionGroup}>
-          <FontAwesome name="eye" size={22} color={colors.textPrimary} />
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.actionGroup} onPress={handleView}>
+          <Animated.View style={{ transform: [{ scale: eyeScale }] }}>
+            <Ionicons name="eye-outline" size={22} color={colors.textPrimary} />
+          </Animated.View>
           <Text style={styles.count}>136K</Text>
-        </View>
+        </TouchableOpacity>
       </View>
     </TouchableOpacity>
   );

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { NavigationContainer, Theme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { FontAwesome } from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons';
+import { Animated } from 'react-native';
 import { colors } from '../styles';
 import { LoginScreen } from '../screens/LoginScreen';
 import { RegisterScreen } from '../screens/RegisterScreen';
@@ -17,11 +18,29 @@ import { ChatScreen } from '../screens/ChatScreen';
 const Stack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
 
+const AnimatedIcon = ({ name, color, size, focused }: { name: any; color: string; size: number; focused: boolean }) => {
+  const scale = React.useRef(new Animated.Value(1)).current;
+
+  React.useEffect(() => {
+    Animated.spring(scale, {
+      toValue: focused ? 1.2 : 1,
+      useNativeDriver: true,
+    }).start();
+  }, [focused]);
+
+  return (
+    <Animated.View style={{ transform: [{ scale }] }}>
+      <Ionicons name={name} size={size} color={color} />
+    </Animated.View>
+  );
+};
+
 function AppTabs() {
   return (
     <Tab.Navigator
       screenOptions={({ route }) => ({
         headerShown: false,
+        animation: 'fade',
         tabBarStyle: {
           backgroundColor: '#111111',
           borderTopLeftRadius: 24,
@@ -31,15 +50,15 @@ function AppTabs() {
         },
         tabBarActiveTintColor: colors.accent,
         tabBarInactiveTintColor: 'rgba(255,255,255,0.7)',
-        tabBarIcon: ({ color, size }) => {
+        tabBarIcon: ({ color, size, focused }) => {
           const icons: any = {
-            Feed: 'home',
-            Search: 'search',
-            Create: 'plus-circle',
-            Community: 'users',
-            Profile: 'user',
+            Feed: focused ? 'home' : 'home-outline',
+            Search: focused ? 'search' : 'search-outline',
+            Create: focused ? 'add-circle' : 'add-circle-outline',
+            Community: focused ? 'people' : 'people-outline',
+            Profile: focused ? 'person' : 'person-outline',
           };
-          return <FontAwesome name={icons[route.name]} size={size} color={color} />;
+          return <AnimatedIcon name={icons[route.name]} size={size} color={color} focused={focused} />;
         },
       })}
     >

--- a/src/screens/FeedScreen.tsx
+++ b/src/screens/FeedScreen.tsx
@@ -1,15 +1,35 @@
 import React from 'react';
-import { View, FlatList, StyleSheet } from 'react-native';
+import { View, FlatList, StyleSheet, Image, TouchableOpacity } from 'react-native';
 import { PostCard } from '../components/PostCard';
 import { colors } from '../styles';
 
+const stories = Array.from({ length: 10 }).map((_, i) => ({ id: `${i}`, seen: i % 3 === 0 }));
+
 export function FeedScreen({ navigation }: any) {
+  const renderStory = ({ item }: any) => (
+    <TouchableOpacity>
+      <View style={[styles.storyItem, !item.seen && styles.unseen]}>
+        <Image source={require('../assets/newspaper.png')} style={styles.storyImage} />
+      </View>
+    </TouchableOpacity>
+  );
+
   return (
     <View style={styles.container}>
       <FlatList
         data={[1, 2, 3]}
         keyExtractor={(item) => item.toString()}
         renderItem={() => <PostCard onPress={() => navigation.navigate('Comments')} />}
+        ListHeaderComponent={
+          <FlatList
+            data={stories}
+            keyExtractor={(item) => item.id}
+            renderItem={renderStory}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.stories}
+          />
+        }
         contentContainerStyle={{ paddingBottom: 80 }}
       />
     </View>
@@ -21,5 +41,27 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
     paddingHorizontal: 0,
+  },
+  stories: {
+    paddingVertical: 16,
+    paddingHorizontal: 8,
+  },
+  storyItem: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    marginRight: 12,
+    borderWidth: 2,
+    borderColor: 'transparent',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  unseen: {
+    borderColor: '#39FF14',
+  },
+  storyImage: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
   },
 });


### PR DESCRIPTION
## Summary
- animate bottom tab icons and add fade transition between tabs
- add Instagram-style stories bar to feed
- modernize post action icons with interactive animations

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689ea80902748320ba2bc139793f2c43