### PR TITLE
style: center register inputs with create account button

### DIFF
--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { StyleSheet, TextInput, TextInputProps } from 'react-native';
 import { colors, radius, spacing } from '../styles';
 
-export function InputField(props: TextInputProps) {
+export function InputField({ style, ...props }: TextInputProps) {
   return (
     <TextInput
       placeholderTextColor="rgba(255,255,255,0.7)"
-      style={styles.input}
+      style={[styles.input, style]}
       {...props}
     />
   );

--- a/src/screens/RegisterScreen.tsx
+++ b/src/screens/RegisterScreen.tsx
@@ -9,12 +9,20 @@ export function RegisterScreen({ navigation }: any) {
     <LinearGradient colors={[ '#2230C3', '#000000' ]} style={styles.container}>
       <View style={styles.inputGroup}>
         <Text style={styles.label}>Informe seu e-mail</Text>
-        <InputField placeholder="" keyboardType="email-address" />
+        <InputField
+          placeholder=""
+          keyboardType="email-address"
+          style={styles.inputField}
+        />
       </View>
 
       <View style={styles.inputGroup}>
         <Text style={styles.label}>Crie sua senha</Text>
-        <InputField placeholder="" secureTextEntry />
+        <InputField
+          placeholder=""
+          secureTextEntry
+          style={styles.inputField}
+        />
       </View>
 
       <TouchableOpacity style={styles.mainButton}>
@@ -35,8 +43,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   inputGroup: {
-    width: '82%',
+    width: 228,
     marginBottom: 16,
+  },
+  inputField: {
+    width: '100%',
   },
   label: {
     color: 'rgba(255,255,255,0.95)',


### PR DESCRIPTION
## Summary
- allow InputField to accept custom styles
- align register screen fields with the create account button

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f4c8ecfdc8320bb9543adb2eba9bf